### PR TITLE
Hack for inserting aladin lite into the DOM

### DIFF
--- a/ipyaladin-anywidget.mjs
+++ b/ipyaladin-anywidget.mjs
@@ -14,13 +14,12 @@ function render({model, el}) {
   aladinDiv.style.height = `${height}px`;
 
   aladinDiv.id = `aladin-lite-div-${idxView}`;
-  console.log(aladinDiv, height)
   // el is not inserted into the DOM. Thus we first directly insert it into the document
   document.body.appendChild(aladinDiv);
   // then we create the aladin lite instance. It will find the div because it is inserted in the DOM
   // TODO: this is a bad workaround, I need to remove the document.querySelector in aladin-lite
   // and only refer to the div given instead.
-  let aladin = new A.aladin(aladinDiv, {showLayersControl: true, projection: "TAN", target, fov: 90});
+  let aladin = new A.aladin(aladinDiv, {showLayersControl: true, showFullscreenControl: false, showContextMenu: true, projection: "TAN", target, fov: 90});
   idxView += 1;
 
   // At this point we remove it from the DOM
@@ -37,7 +36,7 @@ function render({model, el}) {
 
   model.on("change:height", () => {
       let height = model.get("height");
-      el.style.height = `${height}px`;
+      aladinDiv.style.height = `${height}px`;
   });
 
   model.on("change:target", () => {

--- a/ipyaladin-anywidget.mjs
+++ b/ipyaladin-anywidget.mjs
@@ -1,19 +1,30 @@
-import A from "https://esm.sh/aladin-lite@3.2.0";
+import A from "https://esm.sh/aladin-lite@3.3.0-beta";
 
 let idxView = 0
 
-export function render({model, el}) {
+function render({model, el}) {
 
     A.init.then(() => {
-
         let height = model.get("height");
         let target = model.get("target");
 
-        el.setAttribute("style",`width:100%;height:${height}px;`);
-        el.id = `aladin-lite-div-${idxView}`;
+        let aladinDiv = document.createElement('div');
+        aladinDiv.style.height = `${height}px`;
 
-        let aladin = new A.aladin(`#aladin-lite-div-${idxView}`, {projection: "TAN", target: target, showCooGrid: true, fov: 90});
+        aladinDiv.id = `aladin-lite-div-${idxView}`;
+        console.log(aladinDiv, height)
+        // el is not inserted into the DOM. Thus we first directly insert it into the document
+        document.body.appendChild(aladinDiv);
+        // then we create the aladin lite instance. It will find the div because it is inserted in the DOM
+        // TODO: this is a bad workaround, I need to remove the document.querySelector in aladin-lite
+        // and only refer to the div given instead.
+        let aladin = new A.aladin(aladinDiv, {showLayersControl: true, projection: "TAN", target, fov: 90});
+        idxView += 1;
 
+        // At this point we remove it from the DOM
+        aladinDiv.remove();
+        // And append it to el
+        el.appendChild(aladinDiv)
         
         aladin.on("positionChanged", (position) => {
           model.set('ra', position.ra);
@@ -23,20 +34,19 @@ export function render({model, el}) {
         })
 
         model.on("change:height", () => {
-            height = model.get("height");
+            let height = model.get("height");
             el.style.height = `${height}px`;
         });
 
         model.on("change:target", () => {
-          target = model.get("target");
+          let target = model.get("target");
           
           aladin.gotoObject(target)
 
           console.log(aladin.getRaDec())
         })
-
-        el.appendChild(aladin);
-
     });
     
 }
+
+export default { render }

--- a/ipyaladin-anywidget.mjs
+++ b/ipyaladin-anywidget.mjs
@@ -2,51 +2,51 @@ import A from "https://esm.sh/aladin-lite@3.3.0-beta";
 
 let idxView = 0
 
-function render({model, el}) {
-
-    A.init.then(() => {
-        let height = model.get("height");
-        let target = model.get("target");
-
-        let aladinDiv = document.createElement('div');
-        aladinDiv.style.height = `${height}px`;
-
-        aladinDiv.id = `aladin-lite-div-${idxView}`;
-        console.log(aladinDiv, height)
-        // el is not inserted into the DOM. Thus we first directly insert it into the document
-        document.body.appendChild(aladinDiv);
-        // then we create the aladin lite instance. It will find the div because it is inserted in the DOM
-        // TODO: this is a bad workaround, I need to remove the document.querySelector in aladin-lite
-        // and only refer to the div given instead.
-        let aladin = new A.aladin(aladinDiv, {showLayersControl: true, projection: "TAN", target, fov: 90});
-        idxView += 1;
-
-        // At this point we remove it from the DOM
-        aladinDiv.remove();
-        // And append it to el
-        el.appendChild(aladinDiv)
-        
-        aladin.on("positionChanged", (position) => {
-          model.set('ra', position.ra);
-          model.set('dec', position.dec);
-          console.log(model.get('ra'), ' ' ,model.get('dec'))
-          model.save_changes();
-        })
-
-        model.on("change:height", () => {
-            let height = model.get("height");
-            el.style.height = `${height}px`;
-        });
-
-        model.on("change:target", () => {
-          let target = model.get("target");
-          
-          aladin.gotoObject(target)
-
-          console.log(aladin.getRaDec())
-        })
-    });
-    
+async function initialize({ model }) {
+  await A.init;
 }
 
-export default { render }
+function render({model, el}) {
+  let height = model.get("height");
+  let target = model.get("target");
+
+  let aladinDiv = document.createElement('div');
+  aladinDiv.style.height = `${height}px`;
+
+  aladinDiv.id = `aladin-lite-div-${idxView}`;
+  console.log(aladinDiv, height)
+  // el is not inserted into the DOM. Thus we first directly insert it into the document
+  document.body.appendChild(aladinDiv);
+  // then we create the aladin lite instance. It will find the div because it is inserted in the DOM
+  // TODO: this is a bad workaround, I need to remove the document.querySelector in aladin-lite
+  // and only refer to the div given instead.
+  let aladin = new A.aladin(aladinDiv, {showLayersControl: true, projection: "TAN", target, fov: 90});
+  idxView += 1;
+
+  // At this point we remove it from the DOM
+  aladinDiv.remove();
+  // And append it to el
+  el.appendChild(aladinDiv)
+  
+  aladin.on("positionChanged", (position) => {
+    model.set('ra', position.ra);
+    model.set('dec', position.dec);
+    console.log(model.get('ra'), ' ' ,model.get('dec'))
+    model.save_changes();
+  })
+
+  model.on("change:height", () => {
+      let height = model.get("height");
+      el.style.height = `${height}px`;
+  });
+
+  model.on("change:target", () => {
+    let target = model.get("target");
+    
+    aladin.gotoObject(target)
+
+    console.log(aladin.getRaDec())
+  })
+}
+
+export default { initialize, render }

--- a/test.ipynb
+++ b/test.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -13,13 +13,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [],
    "source": [
     "class Ipyaladin(anywidget.AnyWidget):\n",
     "    height = traitlets.Int(400).tag(sync=True)\n",
-    "    target = traitlets.Unicode(\"\").tag(sync=True)\n",
+    "    target = traitlets.Unicode(\"m101\").tag(sync=True)\n",
     "    ra = traitlets.Float().tag(sync=True)\n",
     "    dec = traitlets.Float().tag(sync=True)\n",
     "    _esm = \"ipyaladin-anywidget.mjs\"\n",
@@ -28,7 +28,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -37,13 +37,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "1e6eca114d514318a6a8c38d65ba93c0",
+       "model_id": "c5bd42d6b0dd49b29b1ec72a56a6daa9",
        "version_major": 2,
        "version_minor": 0
       },
@@ -51,7 +51,7 @@
        "Ipyaladin()"
       ]
      },
-     "execution_count": 4,
+     "execution_count": 17,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -62,21 +62,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [],
    "source": [
-    "test.height = 600\n",
-    "\n"
+    "\n",
+    "test.height = 600"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [],
    "source": [
-    "test.target = \"M101\""
+    "test.target = \"M102\""
    ]
   },
   {
@@ -103,7 +103,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.0"
+   "version": "3.10.9"
   }
  },
  "nbformat": 4,

--- a/test.ipynb
+++ b/test.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -13,7 +13,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 19,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -28,7 +28,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 20,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -37,13 +37,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 21,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "c5bd42d6b0dd49b29b1ec72a56a6daa9",
+       "model_id": "8602eaf6e19b48cdb222184e26ef23eb",
        "version_major": 2,
        "version_minor": 0
       },
@@ -51,7 +51,7 @@
        "Ipyaladin()"
       ]
      },
-     "execution_count": 17,
+     "execution_count": 21,
      "metadata": {},
      "output_type": "execute_result"
     }


### PR DESCRIPTION
This is a workaround until I get rid of all the document.querySelector inside aladin-lite. It should unblock a little bit the things for you.